### PR TITLE
Make it work with GPU on Colab

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -119,7 +119,7 @@ def make_binary_dataset(input_file, output_file, dictionary, tokenize=word_token
             tokens_list.append(tokens.numpy())
 
     with open(output_file, 'wb') as outf:
-        pickle.dump(tokens_list, outf, protocol=pickle.HIGHEST_PROTOCOL)
+        pickle.dump(tokens_list, outf, protocol=pickle.DEFAULT_PROTOCOL)
         if not args.quiet:
             logging.info('Built a binary dataset for {}: {} sentences, {} tokens, {:.3f}% replaced by unknown token'.format(
             input_file, nsent, ntok, 100.0 * sum(unk_counter.values()) / ntok, dictionary.unk_word))

--- a/seq2seq/models/lstm.py
+++ b/seq2seq/models/lstm.py
@@ -125,7 +125,7 @@ class LSTMEncoder(Seq2SeqEncoder):
         src_embeddings = _src_embeddings.transpose(0, 1)
 
         # Pack embedded tokens into a PackedSequence
-        packed_source_embeddings = nn.utils.rnn.pack_padded_sequence(src_embeddings, src_lengths)
+        packed_source_embeddings = nn.utils.rnn.pack_padded_sequence(src_embeddings, src_lengths.cpu())
 
         # Pass source input through the recurrent layer(s)
         packed_outputs, (final_hidden_states, final_cell_states) = self.lstm(packed_source_embeddings)

--- a/seq2seq/models/lstm.py
+++ b/seq2seq/models/lstm.py
@@ -117,6 +117,7 @@ class LSTMEncoder(Seq2SeqEncoder):
         batch_size, src_time_steps = src_tokens.size()
         if self.is_cuda:
             src_tokens =  utils.move_to_cuda(src_tokens)
+            src_lengths =  utils.move_to_cuda(src_lengths)
         src_embeddings = self.embedding(src_tokens)
         _src_embeddings = F.dropout(src_embeddings, p=self.dropout_in, training=self.training)
 

--- a/train.py
+++ b/train.py
@@ -16,7 +16,7 @@ from seq2seq.models import ARCH_MODEL_REGISTRY, ARCH_CONFIG_REGISTRY
 def get_args():
     """ Defines training-specific hyper-parameters. """
     parser = argparse.ArgumentParser('Sequence to Sequence Model')
-    parser.add_argument('--cuda', default=False, help='Use a GPU')
+    parser.add_argument('--cuda', action='store_true', help='Use a GPU')
 
     # Add data arguments
     parser.add_argument('--data', default='indomain/preprocessed_data/', help='path to data directory')

--- a/translate.py
+++ b/translate.py
@@ -15,7 +15,7 @@ from seq2seq.data.dataset import Seq2SeqDataset, BatchSampler
 def get_args():
     """ Defines generation-specific hyper-parameters. """
     parser = argparse.ArgumentParser('Sequence to Sequence Model')
-    parser.add_argument('--cuda', default=False, help='Use a GPU')
+    parser.add_argument('--cuda', action='store_true', help='Use a GPU')
     parser.add_argument('--seed', default=42, type=int, help='pseudo random number generator seed')
 
     # Add data arguments


### PR DESCRIPTION
This PR should make it possible to train models on Colab with GPU.

- Move some tensors to the correct devices so that it should work on GPU.
- Simplify the `--cuda` flag (no argument needed).
- Change Pickle protocol to be compatible with Google Colab.

To use it on Colab, we used this successfully:

```
!git clone https://github.com/<my-github-username>/atmt
%cd atmt/
!python3 train.py \
    --data <data-dir> \
    --source-lang fr \
    --target-lang en \
    --save-dir <checkpoints-dir> \
    --cuda
```

*Note* that the preprocessed data in the `data/` folder was produced with a different Pickle protocol, so you will have to re-preprocess them yourself if you want to use them on Colab.

:warning: We haven't tested `translate.py` with `--cuda` yet, it might be necessary to move some more tensors around there. :warning: